### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,13 +3,13 @@ buildscript {
         mavenLocal()
         mavenCentral()
         maven {
-            url "http://repo.spring.io/snapshot"
+            url "https://repo.spring.io/snapshot"
         }
         maven {
-            url "http://repo.spring.io/milestone"
+            url "https://repo.spring.io/milestone"
         }
         maven {
-            url "http://repo.spring.io/release"
+            url "https://repo.spring.io/release"
         }
         jcenter()
     }
@@ -127,13 +127,13 @@ configure(subprojects) {
         mavenLocal()
         mavenCentral()
         maven {
-            url "http://repo.spring.io/snapshot"
+            url "https://repo.spring.io/snapshot"
         }
         maven {
-            url "http://repo.spring.io/milestone"
+            url "https://repo.spring.io/milestone"
         }
         maven {
-            url "http://repo.spring.io/release"
+            url "https://repo.spring.io/release"
         }
         jcenter()
     }


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://repo.spring.io/milestone with 2 occurrences migrated to:  
  https://repo.spring.io/milestone ([https](https://repo.spring.io/milestone) result 302).
* http://repo.spring.io/release with 2 occurrences migrated to:  
  https://repo.spring.io/release ([https](https://repo.spring.io/release) result 302).
* http://repo.spring.io/snapshot with 2 occurrences migrated to:  
  https://repo.spring.io/snapshot ([https](https://repo.spring.io/snapshot) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost with 1 occurrences