### PR TITLE
Gradle Daemon is important for performance

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.daemon=false
+org.gradle.daemon=true
 
 BOOT_VERSION=2.6.2-SNAPSHOT
 BOM_VERSION=2021.0.1-SNAPSHOT

--- a/runAcceptanceTests.sh
+++ b/runAcceptanceTests.sh
@@ -608,7 +608,7 @@ if [[ "${CLOUD_FOUNDRY}" == "true" ]] ; then
     WHAT_TO_TEST="SLEUTH"
 fi
 
-PARAMS="--no-daemon";
+PARAMS="--daemon";
 if [[ "${WORK_OFFLINE}" == "false" ]]; then
     PARAMS="${PARAMS} --refresh-dependencies";
 else
@@ -773,7 +773,7 @@ fi
 if [[ "${READY_FOR_TESTS}" == "yes" ]] ; then
     echo -e "\n\nSuccessfully booted up all the apps. Proceeding with the acceptance tests"
     echo -e "\n\nRunning acceptance tests with the following parameters [-DWHAT_TO_TEST=${WHAT_TO_TEST} ${ACCEPTANCE_TEST_OPTS}]"
-    ./gradlew ${PARAMS} :acceptance-tests:acceptanceTests "-DWHAT_TO_TEST=${WHAT_TO_TEST}" ${ACCEPTANCE_TEST_OPTS} --stacktrace --no-daemon --configure-on-demand && TESTS_PASSED="yes"
+    ./gradlew ${PARAMS} :acceptance-tests:acceptanceTests "-DWHAT_TO_TEST=${WHAT_TO_TEST}" ${ACCEPTANCE_TEST_OPTS} --stacktrace --daemon --configure-on-demand && TESTS_PASSED="yes"
 fi
 
 if [[ "${TESTS_PASSED}" == "yes" ]] ; then


### PR DESCRIPTION

[Gradle daemon](https://docs.gradle.org/current/userguide/gradle_daemon.html#header). The Daemon is a long-lived process that help to avoid the cost of JVM startup for every build. Since Gradle 3.0, Gradle daemon is enabled by default. For an older version, you should enable it by setting `org.gradle.daemon=true`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
